### PR TITLE
Module for node.js

### DIFF
--- a/nodejs/homegate.js
+++ b/nodejs/homegate.js
@@ -1,0 +1,73 @@
+var https = require('https');
+
+
+const API_KEY = "<REPLACE ME>";
+
+
+module.exports = {
+  search: search,
+  details: details,
+};
+
+
+function _composeGet(param_sets) {
+  // compose GET parameters
+  get = [];
+
+  for (var k in param_sets) {
+    var set = param_sets[k];
+    for (var p in set) {
+      get.push(encodeURIComponent(p) + '=' + encodeURIComponent(set[p]));
+    }
+  }
+
+  return get.join('&');
+}
+
+function _homegateReq(path, callback) {
+  var req_params = {
+    protocol: "https:",
+    host: "api-2445581357976.apicast.io",
+    path: "/rs/real-estates" + path,
+    port: 443,
+    headers: {
+      'Accept': 'application/json',
+      'auth': API_KEY
+    }
+  };
+
+  req = https.request(req_params, function (resp) {
+    var str = '';
+
+    resp.on('data', function (chunk) {
+      str += chunk;
+    });
+
+    resp.on('end', function () {
+      callback(JSON.parse(str));
+    });
+
+    resp.on('error', function () {
+      console.log('ERR: homegate API query failed');
+      callback(null);
+    });
+  });
+
+  req.end();
+}
+
+
+function search(search_params, callback) {
+  parameters = {
+    'language': 'en',
+    'chooseType': 'rentflat',
+  };
+  path = '?' + _composeGet([parameters, search_params]);
+
+  _homegateReq(path, callback);
+};
+
+
+function details(advId, callback) {
+  _homegateReq('/' + advId, callback);
+}


### PR DESCRIPTION
Simple helper for node.js that makes querying the API easy. Set the API key and
use it like this:

    var homegate = require("./homegate.js");

    homegate.search(
      {
        'priceTo': '2000',
      },
      function (result) {
        console.log(result);
      }
    );

    homegate.details(105321232, function (result) {
        console.log(result);
    });